### PR TITLE
Remove also watch from calling setUI with 'clock' (alternative 1 of 2)

### DIFF
--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -26,7 +26,6 @@ NRF.sleep();
 
 // events
 Bangle.removeAllListeners();
-clearWatch();
 
 // UI
 Bangle.setOptions({
@@ -71,6 +70,7 @@ Bangle.setUI({
     nextDraw = undefined;
   },
 });
+clearWatch();
 
 g.clear();
 draw();


### PR DESCRIPTION
> ['clock' - called for clocks. Sets Bangle.CLOCK=1 and allows a button to start the launcher](https://www.espruino.com/Reference#l_Bangle_setUI)

There is another way to do this as well, will do a separate PR for that so you can choose.

https://github.com/espruino/BangleApps/pull/2684