### PR TITLE
Change to 'custom' mode in setUI to not add button watch to start launcher (alternative 2 of 2)

### DIFF
--- a/apps/drained/app.ts
+++ b/apps/drained/app.ts
@@ -65,12 +65,13 @@ const draw = () => {
 };
 
 Bangle.setUI({
-  mode: "clock",
+  mode: "custom",
   remove: () => {
     if (nextDraw) clearTimeout(nextDraw);
     nextDraw = undefined;
   },
 });
+Bangle.CLOCK=1;
 
 g.clear();
 draw();


### PR DESCRIPTION
> ['clock' - called for clocks. Sets Bangle.CLOCK=1 and allows a button to start the launcher](https://www.espruino.com/Reference#l_Bangle_setUI)

Use one of these PRs if you want. I think it makes sense to not be able to press the HW button to start the launcher, as I wrote before :) (long press to reset still works, as well as kicking the watchdog of course)